### PR TITLE
PCM-15818 Game Input

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -112,7 +112,7 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
         self.addBottomSpaceView()
         self.setupKeyboardTracker()
         self.setupTapGestureRecognizer()
-        if let status = keyboardTracker?.keyboardStatus {
+        if let status = keyboardTracker?.getStatus() {
             self.setUserInteraction(withStatus: status)
         }
     }

--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -112,6 +112,9 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
         self.addBottomSpaceView()
         self.setupKeyboardTracker()
         self.setupTapGestureRecognizer()
+        if let status = keyboardTracker?.keyboardStatus {
+            self.setUserInteraction(withStatus: status)
+        }
     }
 
     private func setupTapGestureRecognizer() {
@@ -236,11 +239,16 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
     }
 
     open func handleKeyboardPositionChange(bottomMargin: CGFloat, keyboardStatus: KeyboardStatus) {
+        setUserInteraction(withStatus: keyboardStatus)
         guard self.inputContainerBottomConstraint.constant != bottomMargin else { return }
         self.isAdjustingInputContainer = true
         self.inputContainerBottomConstraint.constant = max(bottomMargin, self.bottomLayoutGuide.length)
         self.view.layoutIfNeeded()
         self.isAdjustingInputContainer = false
+    }
+
+    open func setUserInteraction(withStatus keyboardStatus: KeyboardStatus) {
+        // default implementation is to do nothing
     }
 
     var notificationCenter = NotificationCenter.default

--- a/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
+++ b/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
@@ -195,6 +195,10 @@ class KeyboardTracker {
         self.layoutBlock(constraint, self.keyboardStatus)
         self.isPerformingForcedLayout = false
     }
+
+    func getStatus() -> KeyboardStatus {
+        return keyboardStatus
+    }
 }
 
 private class KeyboardTrackingView: UIView {


### PR DESCRIPTION
Added a method to KeyboardTracker to grab the KeyboardTracker.keyboardStatus

In BaseChatViewController added an override-able method that is called 1) when the View Controller is done loading, and 2) when there is a change in the KeyboardStatus.

We can override this method in EAGLViewController to disable BaseChatViewController.collectionView's userInteraction while the keyboard is hidden