### PR TITLE
feat: Remove our added keyboard status methods

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -123,9 +123,6 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
         self.addInputContentContainer()
         self.setupKeyboardTracker()
         self.setupTapGestureRecognizer()
-        if let status = keyboardTracker?.getStatus() {
-            self.setUserInteraction(withStatus: status)
-        }
     }
 
     private func setupTapGestureRecognizer() {
@@ -279,16 +276,11 @@ open class BaseChatViewController: UIViewController, UICollectionViewDataSource,
     }
 
     open func handleKeyboardPositionChange(bottomMargin: CGFloat, keyboardStatus: KeyboardStatus) {
-        setUserInteraction(withStatus: keyboardStatus)
         guard self.inputContainerBottomConstraint.constant != bottomMargin else { return }
         self.isAdjustingInputContainer = true
         self.inputContainerBottomConstraint.constant = max(bottomMargin, self.bottomLayoutGuide.length)
         self.view.layoutIfNeeded()
         self.isAdjustingInputContainer = false
-    }
-
-    open func setUserInteraction(withStatus keyboardStatus: KeyboardStatus) {
-        // default implementation is to do nothing
     }
 
     var notificationCenter = NotificationCenter.default

--- a/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
+++ b/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
@@ -203,10 +203,6 @@ class KeyboardTracker {
         self.heightBlock(constraint, self.keyboardStatus)
         self.isPerformingForcedLayout = false
     }
-
-    func getStatus() -> KeyboardStatus {
-        return keyboardStatus
-    }
 }
 
 private class KeyboardTrackingView: UIView {


### PR DESCRIPTION
Changes made to BaseChatViewController and KeyboardTracker to track the keyboard status are no longer necessary as Chatto has added a way to get keyboard updates