### PR TITLE
[Keyboard] Fix keyboard issue for `iOS 26` because of `positionChangedCallback` (#5507)

### DIFF
--- a/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
+++ b/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
@@ -270,6 +270,10 @@ private class KeyboardTrackingView: UIView {
             let oldCenter = (sChange[NSKeyValueChangeKey.oldKey] as! NSValue).cgPointValue
             let newCenter = (sChange[NSKeyValueChangeKey.newKey] as! NSValue).cgPointValue
             if oldCenter != newCenter {
+                // On iOS 26, during a user swipe to close the screen and cancel this swipe, the system sends a notification to `UIKeyboardItemContainerView`, during which the `KeyboardTrackingView` has a negative `Y`, which leads to incorrect calculation of the bottom margin. On iOS 18 and older, this method is not called at all in this case.
+                if #available(iOS 26.0, *), self.frame.minY < 0 {
+                    return
+                }
                 self.positionChangedCallback?()
             }
         }


### PR DESCRIPTION
# Description

|BUG|FIX|
|---|---|
|<video src="https://github.com/user-attachments/assets/76672269-7480-4353-b204-3d783e645b88"/>|<video src="https://github.com/user-attachments/assets/f640b608-9c91-4e81-9902-975c43dac3ac"/>|