### PR TITLE
Support Swift Package Manager

### DIFF
--- a/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCellDefaultStyle.swift
@@ -215,16 +215,16 @@ public extension BaseMessageCollectionViewCellDefaultStyle { // Default values
 
     static func createDefaultBubbleBorderImages() -> BubbleBorderImages {
         return BubbleBorderImages(
-            borderIncomingTail: UIImage(named: "bubble-incoming-border-tail", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            borderIncomingNoTail: UIImage(named: "bubble-incoming-border", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            borderOutgoingTail: UIImage(named: "bubble-outgoing-border-tail", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            borderOutgoingNoTail: UIImage(named: "bubble-outgoing-border", in: Bundle(for: Class.self), compatibleWith: nil)!
+            borderIncomingTail: UIImage(named: "bubble-incoming-border-tail", in: Bundle.resources, compatibleWith: nil)!,
+            borderIncomingNoTail: UIImage(named: "bubble-incoming-border", in: Bundle.resources, compatibleWith: nil)!,
+            borderOutgoingTail: UIImage(named: "bubble-outgoing-border-tail", in: Bundle.resources, compatibleWith: nil)!,
+            borderOutgoingNoTail: UIImage(named: "bubble-outgoing-border", in: Bundle.resources, compatibleWith: nil)!
         )
     }
 
     static func createDefaultFailedIconImages() -> FailedIconImages {
         let normal = {
-            return UIImage(named: "base-message-failed-icon", in: Bundle(for: Class.self), compatibleWith: nil)!
+            return UIImage(named: "base-message-failed-icon", in: Bundle.resources, compatibleWith: nil)!
         }
         return FailedIconImages(
             normal: normal(),
@@ -243,8 +243,8 @@ public extension BaseMessageCollectionViewCellDefaultStyle { // Default values
                                                             maxContainerWidthPercentageForBubbleView: 0.68)
     }
 
-    private static let selectionIndicatorIconSelected = UIImage(named: "base-message-checked-icon", in: Bundle(for: Class.self), compatibleWith: nil)!.bma_tintWithColor(BaseMessageCollectionViewCellDefaultStyle.defaultOutgoingColor)
-    private static let selectionIndicatorIconDeselected = UIImage(named: "base-message-unchecked-icon", in: Bundle(for: Class.self), compatibleWith: nil)!.bma_tintWithColor(UIColor.bma_color(rgb: 0xC6C6C6))
+    private static let selectionIndicatorIconSelected = UIImage(named: "base-message-checked-icon", in: Bundle.resources, compatibleWith: nil)!.bma_tintWithColor(BaseMessageCollectionViewCellDefaultStyle.defaultOutgoingColor)
+    private static let selectionIndicatorIconDeselected = UIImage(named: "base-message-unchecked-icon", in: Bundle.resources, compatibleWith: nil)!.bma_tintWithColor(UIColor.bma_color(rgb: 0xC6C6C6))
 
     static func createDefaultSelectionIndicatorStyle() -> SelectionIndicatorStyle {
         return SelectionIndicatorStyle(

--- a/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleViewStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/CompoundMessage/Views/CompoundBubbleViewStyle.swift
@@ -117,7 +117,7 @@ extension DefaultCompoundBubbleViewStyle.BubbleMasks {
     }
 
     public static var `default`: DefaultCompoundBubbleViewStyle.BubbleMasks {
-        let bundle = Bundle(for: DefaultCompoundBubbleViewStyle.self)
+        let bundle = Bundle.resources
         return DefaultCompoundBubbleViewStyle.BubbleMasks(
             incomingTail: UIImage(named: "bubble-incoming-tail", in: bundle, compatibleWith: nil)!,
             incomingNoTail: UIImage(named: "bubble-incoming", in: bundle, compatibleWith: nil)!,

--- a/ChattoAdditions/Source/Chat Items/PhotoMessages/Views/PhotoMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/PhotoMessages/Views/PhotoMessageCollectionViewCellDefaultStyle.swift
@@ -113,7 +113,7 @@ open class PhotoMessageCollectionViewCellDefaultStyle: PhotoMessageCollectionVie
     }()
 
     lazy private var placeholderIcon: UIImage = {
-        return UIImage(named: "photo-bubble-placeholder-icon", in: Bundle(for: Class.self), compatibleWith: nil)!
+        return UIImage(named: "photo-bubble-placeholder-icon", in: Bundle.resources, compatibleWith: nil)!
     }()
 
     open func maskingImage(viewModel: PhotoMessageViewModelProtocol) -> UIImage {
@@ -176,10 +176,10 @@ public extension PhotoMessageCollectionViewCellDefaultStyle { // Default values
 
     static func createDefaultBubbleMasks() -> BubbleMasks {
         return BubbleMasks(
-            incomingTail: UIImage(named: "bubble-incoming-tail", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            incomingNoTail: UIImage(named: "bubble-incoming", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            outgoingTail: UIImage(named: "bubble-outgoing-tail", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            outgoingNoTail: UIImage(named: "bubble-outgoing", in: Bundle(for: Class.self), compatibleWith: nil)!,
+            incomingTail: UIImage(named: "bubble-incoming-tail", in: Bundle.resources, compatibleWith: nil)!,
+            incomingNoTail: UIImage(named: "bubble-incoming", in: Bundle.resources, compatibleWith: nil)!,
+            outgoingTail: UIImage(named: "bubble-outgoing-tail", in: Bundle.resources, compatibleWith: nil)!,
+            outgoingNoTail: UIImage(named: "bubble-outgoing", in: Bundle.resources, compatibleWith: nil)!,
             tailWidth: 6
         )
     }

--- a/ChattoAdditions/Source/Chat Items/TextMessages/Views/TextMessageCollectionViewCellDefaultStyle.swift
+++ b/ChattoAdditions/Source/Chat Items/TextMessages/Views/TextMessageCollectionViewCellDefaultStyle.swift
@@ -151,10 +151,10 @@ public extension TextMessageCollectionViewCellDefaultStyle { // Default values
 
     static func createDefaultBubbleImages() -> BubbleImages {
         return BubbleImages(
-            incomingTail: UIImage(named: "bubble-incoming-tail", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            incomingNoTail: UIImage(named: "bubble-incoming", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            outgoingTail: UIImage(named: "bubble-outgoing-tail", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            outgoingNoTail: UIImage(named: "bubble-outgoing", in: Bundle(for: Class.self), compatibleWith: nil)!
+            incomingTail: UIImage(named: "bubble-incoming-tail", in: Bundle.resources, compatibleWith: nil)!,
+            incomingNoTail: UIImage(named: "bubble-incoming", in: Bundle.resources, compatibleWith: nil)!,
+            outgoingTail: UIImage(named: "bubble-outgoing-tail", in: Bundle.resources, compatibleWith: nil)!,
+            outgoingNoTail: UIImage(named: "bubble-outgoing", in: Bundle.resources, compatibleWith: nil)!
         )
     }
 

--- a/ChattoAdditions/Source/Common/Bundle+Resources.swift
+++ b/ChattoAdditions/Source/Common/Bundle+Resources.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension Bundle {
+    /// The bundle that holds ChattoAdditions' own xibs and asset catalogs.
+    /// Swift Package Manager puts them in a generated resource bundle, CocoaPods leaves them in the framework itself.
+    static let resources: Bundle = {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: BundleToken.self)
+        #endif
+    }()
+}
+
+private final class BundleToken {}

--- a/ChattoAdditions/Source/Input/ChatInputBar.swift
+++ b/ChattoAdditions/Source/Input/ChatInputBar.swift
@@ -69,7 +69,7 @@ open class ChatInputBar: ReusableXibView {
     @IBOutlet var tabBarContainerHeightConstraint: NSLayoutConstraint!
 
     class open func loadNib() -> ChatInputBar {
-        let view = Bundle(for: self).loadNibNamed(self.nibName(), owner: nil, options: nil)!.first as! ChatInputBar
+        let view = Bundle.resources.loadNibNamed(self.nibName(), owner: nil, options: nil)!.first as! ChatInputBar
         view.translatesAutoresizingMaskIntoConstraints = false
         view.frame = CGRect.zero
         return view

--- a/ChattoAdditions/Source/Input/ExpandableChatInputBarPresenter.swift
+++ b/ChattoAdditions/Source/Input/ExpandableChatInputBarPresenter.swift
@@ -22,6 +22,7 @@
  THE SOFTWARE.
  */
 
+import UIKit
 import Chatto
 
 @objc

--- a/ChattoAdditions/Source/Input/Photos/Camera/LiveCameraCell.swift
+++ b/ChattoAdditions/Source/Input/Photos/Camera/LiveCameraCell.swift
@@ -43,8 +43,8 @@ public struct LiveCameraCellAppearance {
     public static func createDefaultAppearance() -> LiveCameraCellAppearance {
         return LiveCameraCellAppearance(
             backgroundColor: UIColor(red: 24.0/255.0, green: 101.0/255.0, blue: 245.0/255.0, alpha: 1),
-            cameraImage: UIImage(named: "camera", in: Bundle(for: LiveCameraCell.self), compatibleWith: nil),
-            cameraLockImage: UIImage(named: "camera_lock", in: Bundle(for: LiveCameraCell.self), compatibleWith: nil)
+            cameraImage: UIImage(named: "camera", in: Bundle.resources, compatibleWith: nil),
+            cameraLockImage: UIImage(named: "camera_lock", in: Bundle.resources, compatibleWith: nil)
         )
     }
 }

--- a/ChattoAdditions/Source/Input/Photos/PhotosChatInputItem.swift
+++ b/ChattoAdditions/Source/Input/Photos/PhotosChatInputItem.swift
@@ -47,9 +47,9 @@ open class PhotosChatInputItem: ChatInputItemProtocol {
 
     public static func createDefaultButtonAppearance() -> TabInputButtonAppearance {
         let images: [UIControlStateWrapper: UIImage] = [
-            UIControlStateWrapper(state: .normal): UIImage(named: "camera-icon-unselected", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            UIControlStateWrapper(state: .selected): UIImage(named: "camera-icon-selected", in: Bundle(for: Class.self), compatibleWith: nil)!,
-            UIControlStateWrapper(state: .highlighted): UIImage(named: "camera-icon-selected", in: Bundle(for: Class.self), compatibleWith: nil)!
+            UIControlStateWrapper(state: .normal): UIImage(named: "camera-icon-unselected", in: Bundle.resources, compatibleWith: nil)!,
+            UIControlStateWrapper(state: .selected): UIImage(named: "camera-icon-selected", in: Bundle.resources, compatibleWith: nil)!,
+            UIControlStateWrapper(state: .highlighted): UIImage(named: "camera-icon-selected", in: Bundle.resources, compatibleWith: nil)!
         ]
         return TabInputButtonAppearance(images: images, size: nil)
     }

--- a/ChattoAdditions/Source/Input/Photos/Placeholder/PhotosInputPlaceholderCell.swift
+++ b/ChattoAdditions/Source/Input/Photos/Placeholder/PhotosInputPlaceholderCell.swift
@@ -46,7 +46,7 @@ final class PhotosInputPlaceholderCell: UICollectionViewCell {
     private func commonInit() {
         self.imageView = UIImageView()
         self.imageView.contentMode = .center
-        self.imageView.image = UIImage(named: Constants.imageName, in: Bundle(for: PhotosInputPlaceholderCell.self), compatibleWith: nil)
+        self.imageView.image = UIImage(named: Constants.imageName, in: Bundle.resources, compatibleWith: nil)
         self.contentView.addSubview(self.imageView)
         self.contentView.backgroundColor = Constants.backgroundColor
         self.accessibilityIdentifier = Constants.accessibilityIdentifier

--- a/ChattoAdditions/Source/Input/Text/TextChatInputItem.swift
+++ b/ChattoAdditions/Source/Input/Text/TextChatInputItem.swift
@@ -35,9 +35,9 @@ open class TextChatInputItem {
 
     public static func createDefaultButtonAppearance() -> TabInputButtonAppearance {
         let images: [UIControlStateWrapper: UIImage] = [
-            UIControlStateWrapper(state: .normal): UIImage(named: "text-icon-unselected", in: Bundle(for: TextChatInputItem.self), compatibleWith: nil)!,
-            UIControlStateWrapper(state: .selected): UIImage(named: "text-icon-selected", in: Bundle(for: TextChatInputItem.self), compatibleWith: nil)!,
-            UIControlStateWrapper(state: .highlighted): UIImage(named: "text-icon-selected", in: Bundle(for: TextChatInputItem.self), compatibleWith: nil)!
+            UIControlStateWrapper(state: .normal): UIImage(named: "text-icon-unselected", in: Bundle.resources, compatibleWith: nil)!,
+            UIControlStateWrapper(state: .selected): UIImage(named: "text-icon-selected", in: Bundle.resources, compatibleWith: nil)!,
+            UIControlStateWrapper(state: .highlighted): UIImage(named: "text-icon-selected", in: Bundle.resources, compatibleWith: nil)!
         ]
         return TabInputButtonAppearance(images: images, size: nil)
     }

--- a/ChattoAdditions/Source/UI Components/CircleProgressIndicatorView/CircleIconView.swift
+++ b/ChattoAdditions/Source/UI Components/CircleProgressIndicatorView/CircleIconView.swift
@@ -200,7 +200,7 @@ final class CircleIconView: UIView {
                 return nil
             }
             }() else { return }
-        self.iconView.image = UIImage(named: imageName, in: Bundle(for: CircleIconView.self), compatibleWith: nil)
+        self.iconView.image = UIImage(named: imageName, in: Bundle.resources, compatibleWith: nil)
     }
 
     private func setupIconPoints(with type: CircleIconType) {

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "Chatto",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(name: "Chatto", targets: ["Chatto"]),
+        .library(name: "ChattoAdditions", targets: ["ChattoAdditions"])
+    ],
+    targets: [
+        .target(
+            name: "Chatto",
+            path: "Chatto/Source",
+            exclude: ["Info.plist"]
+        ),
+        .target(
+            name: "ChattoAdditions",
+            dependencies: ["Chatto"],
+            path: "ChattoAdditions/Source",
+            exclude: ["Info.plist"],
+            resources: [
+                .process("Input/ChatInputBar.xib"),
+                .process("Input/Text/Text.xcassets"),
+                .process("Input/Photos/Photos.xcassets"),
+                .process("UI Components/CircleProgressIndicatorView/CircleProgressIndicator.xcassets"),
+                .process("Chat Items/BaseMessage/Views/BaseMessageAssets.xcassets"),
+                .process("Chat Items/PhotoMessages/Views/PhotoMessageAssets.xcassets")
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
## Description

Chatto and ChattoAdditions can now be used as Swift packages. iPlato is moving off CocoaPods, and these two were the last source pods left.

`Package.swift` uses the same source paths as the podspecs, so both package managers describe the same code and the podspecs stay valid.

Two source changes are needed, because CocoaPods was quietly providing what a package does not:

- **UIKit import.** CocoaPods builds ChattoAdditions as a framework whose umbrella header imports UIKit, and the module map re-exports it, so every file in the module saw UIKit without asking for it. `ExpandableChatInputBarPresenter` relied on that. It now imports UIKit itself.
- **Resource lookup.** CocoaPods keeps the xibs and asset catalogs inside `ChattoAdditions.framework`, where `Bundle(for:)` finds them. Swift Package Manager puts them in a generated resource bundle that only `Bundle.module` knows. One `Bundle.resources` accessor picks the right bundle, and all 28 lookups go through it. Several of them force-unwrap the image they load, so the wrong bundle means a crash, not a missing icon.

## Notes

`ReusableXibView` keeps `Bundle(for: type(of: self))` on purpose. Its subclasses outside this module load their own xib from their own bundle, and iPlato has one.

`Bundle.resources` keeps a `#if SWIFT_PACKAGE` fallback, so nothing changes for a CocoaPods consumer.

Verified by building a consumer package for iOS: the generated `Chatto_ChattoAdditions.bundle` carries `Assets.car` and `ChatInputBar.nib`, and instantiating `ChatInputBar` with the base, text, photo and compound default styles compiles and links. Both iPlato apps and its test bundle build against it too.

This targets the release line that carries tag `4.0.4`, the version iPlato pins today. After merging, the line gets tag `4.0.5` and iPlato resolves that exact version.

Part of plato-app/iPlato#7129.
